### PR TITLE
Load all models from replicate weights cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,4 @@ __pycache__
 
 # Exclude Python virtual environment
 /venv
+/model-cache/

--- a/cog.yaml
+++ b/cog.yaml
@@ -12,7 +12,7 @@ build:
     - "compel"
 
   run:
-    - curl -o /usr/local/bin/pget -L "https://github.com/replicate/pget/releases/download/v0.0.3/pget" && chmod +x /usr/local/bin/pget
+    - curl -o /usr/local/bin/pget -L "https://github.com/replicate/pget/releases/download/v0.3.1/pget" && chmod +x /usr/local/bin/pget
 
 # predict.py defines how predictions are run on your model
 predict: "predict.py:Predictor"

--- a/predict.py
+++ b/predict.py
@@ -32,6 +32,7 @@ SCHEDULERS = {
 
 MODEL_CACHE="model-cache"
 os.environ['HUGGINGFACE_HUB_CACHE'] = MODEL_CACHE
+os.environ['HF_HUB_OFFLINE'] = 1
 
 MODELS = [
     {


### PR DESCRIPTION
Instead of downloading the weights for blip-large and the laion clip model from HuggingFace, load them from Replicate's weights cache. 